### PR TITLE
docs: document required GitHub App permissions and PAT scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,29 @@ This action can be configured to authenticate with GitHub App Installation or Pe
 | `GH_APP_PRIVATE_KEY`         | True     | `""`    | GitHub Application Private Key. See [documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app) for more details.     |
 | `GITHUB_APP_ENTERPRISE_ONLY` | False    | `false` | Set this input to `true` if your app is created in GHE and communicates with GHE.                                                                                                                       |
 
+###### Required GitHub App permissions
+
+The GitHub App must be installed on every repository the action will scan
+(or installed on the organization with "All repositories" selected), and the
+App must be granted these permissions:
+
+- **Repository → Metadata**: Read (default)
+- **Repository → Contents**: Read & write — read CODEOWNERS files; create branches and commit the placeholder CODEOWNERS file when one is missing
+- **Repository → Pull requests**: Read & write — open PRs that suggest CODEOWNERS changes
+- **Organization → Members**: Read — check whether each CODEOWNERS entry is still an organization member
+
+If any of these are missing the action fails with `Error: 403 Resource not accessible by integration` on the first API call that needs the missing permission. Updating an existing App's permissions also requires the installation owner to accept the new permission request before it takes effect.
+
 ##### Personal Access Token (PAT)
 
-| field      | required | default | description                                                                                                           |
-| ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| `GH_TOKEN` | True     | `""`    | The GitHub Token used to scan the repository. Must have read access to all repository you are interested in scanning. |
+| field      | required | default | description                                                            |
+| ---------- | -------- | ------- | ---------------------------------------------------------------------- |
+| `GH_TOKEN` | True     | `""`    | The GitHub Token used to scan repositories. See required scopes below. |
+
+###### Required PAT scopes
+
+- **Classic PAT**: `repo` (read & write to repository contents and pull requests) and `read:org` (organization membership checks)
+- **Fine-grained PAT**: for every target repository — **Contents**: Read & write, **Pull requests**: Read & write, **Metadata**: Read; for the organization — **Members**: Read
 
 #### Other Configuration Options
 


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Added a **Required GitHub App permissions** subsection under the GitHub App Installation auth table that lists the exact permissions the action needs:

- Repository → Metadata: Read
- Repository → Contents: Read & write
- Repository → Pull requests: Read & write
- Organization → Members: Read

Added a corresponding **Required PAT scopes** subsection covering both classic (`repo`, `read:org`) and fine-grained PAT setups, and corrected the `GH_TOKEN` field description that previously said *"Must have read access to all repository you are interested in scanning"* — the action also opens PRs, so read-only is insufficient.

## Why

Until now the README left users to discover required permissions by trial and error. When any required permission is missing, the action fails with `Error: 403 Resource not accessible by integration` on the first API call that needs it, which is opaque and hard to map back to a specific App or PAT setting. Documenting the explicit permission set up front cuts that debugging loop. Also helps installation owners know they need to accept the new permission request on the org installation after the App definition is updated.

## Testing

- Verified each permission against the actual API calls in `cleanowners.py`:
  - `gh_org.is_member(username)` → Organization Members: Read
  - `repo.file_contents(...)` / `repo.blob(...)` → Repository Contents: Read
  - `repo.create_ref(...)`, `repo.create_file(...)`, `file_contents.update(...)` → Repository Contents: Write
  - `repo.create_pull(...)` → Repository Pull requests: Write
- Reproduced the 403 in a downstream consumer (App had Contents: Read only); after granting Contents: Write on the App and accepting the installation's new permission request, the next workflow run succeeded.
- `make test` → 74 tests pass with 100% coverage
- `markdownlint-cli2 --config .github/linters/.markdown-lint.yml README.md` → 0 errors

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing