### PR TITLE
refactor: port from github3.py to PyGithub

### DIFF
--- a/.github/linters/.mypy.ini
+++ b/.github/linters/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 disable_error_code = attr-defined, import-not-found
 
-[mypy-github3.*]
+[mypy-github.*]
 ignore_missing_imports = True

--- a/auth.py
+++ b/auth.py
@@ -25,6 +25,7 @@ def auth_to_github(
     Returns:
         Github: the GitHub connection object
     """
+    ghe = ghe.rstrip("/")
     if gh_app_id and gh_app_private_key_bytes and gh_app_installation_id:
         app_auth = Auth.AppAuth(int(gh_app_id), gh_app_private_key_bytes.decode())
         installation_auth = app_auth.get_installation_auth(int(gh_app_installation_id))

--- a/auth.py
+++ b/auth.py
@@ -1,6 +1,6 @@
 """This is the module that contains functions related to authenticating to GitHub with a personal access token."""
 
-import github3
+from github import Auth, Github
 
 
 def auth_to_github(
@@ -10,7 +10,7 @@ def auth_to_github(
     gh_app_private_key_bytes: bytes,
     ghe: str,
     gh_app_enterprise_only: bool,
-) -> github3.GitHub:
+) -> Github:
     """
     Connect to GitHub.com or GitHub Enterprise, depending on env variables.
 
@@ -23,26 +23,22 @@ def auth_to_github(
         gh_app_enterprise_only (bool): Set this to true if the GH APP is created on GHE and needs to communicate with GHE api only
 
     Returns:
-        github3.GitHub: the GitHub connection object
+        Github: the GitHub connection object
     """
     if gh_app_id and gh_app_private_key_bytes and gh_app_installation_id:
+        app_auth = Auth.AppAuth(int(gh_app_id), gh_app_private_key_bytes.decode())
+        installation_auth = app_auth.get_installation_auth(int(gh_app_installation_id))
         if ghe and gh_app_enterprise_only:
-            gh = github3.github.GitHubEnterprise(url=ghe)
+            github_connection = Github(base_url=f"{ghe}/api/v3", auth=installation_auth)
         else:
-            gh = github3.github.GitHub()
-        gh.login_as_app_installation(
-            gh_app_private_key_bytes, str(gh_app_id), gh_app_installation_id
-        )
-        github_connection = gh
+            github_connection = Github(auth=installation_auth)
     elif ghe and token:
-        github_connection = github3.github.GitHubEnterprise(url=ghe, token=token)
+        github_connection = Github(base_url=f"{ghe}/api/v3", auth=Auth.Token(token))
     elif token:
-        github_connection = github3.login(token=token)
+        github_connection = Github(auth=Auth.Token(token))
     else:
         raise ValueError(
             "GH_TOKEN or the set of [GH_APP_ID, GH_APP_INSTALLATION_ID, GH_APP_PRIVATE_KEY] environment variables are not set"
         )
 
-    if not github_connection:
-        raise ValueError("Unable to authenticate to GitHub")
-    return github_connection  # type: ignore
+    return github_connection

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -6,7 +6,7 @@ import uuid
 
 import auth
 import env
-from github import GithubException
+from github import GithubException, UnknownObjectException
 from markdown_writer import write_step_summary, write_to_markdown
 
 
@@ -14,7 +14,7 @@ def get_org(github_connection, organization):
     """Get the organization object"""
     try:
         return github_connection.get_organization(organization)
-    except GithubException:
+    except UnknownObjectException:
         print(f"Organization {organization} not found")
         return None
 
@@ -165,17 +165,19 @@ def main():  # pragma: no cover
                     pull_count += 1
                     pull_request_urls.append(pull.html_url)
                     print(f"\tCreated pull request {pull.html_url}")
-                except GithubException:
-                    print("\tFailed to create pull request. Check write permissions.")
+                except GithubException as e:
+                    print(
+                        f"\tFailed to create pull request"
+                        f" (status {e.status}): {e.data}."
+                        f" Check write permissions."
+                    )
                 continue
 
             codeowners_count += 1
 
-            if codeowners_file_contents.content is None:
-                blob = repo.get_git_blob(repo.get_contents(codeowners_filepath).sha)
-                codeowners_decoded = blob.content.encode("utf-8")
-                if blob.encoding == "base64":
-                    codeowners_decoded = base64.b64decode(blob.content)
+            if codeowners_file_contents.encoding == "none":
+                blob = repo.get_git_blob(codeowners_file_contents.sha)
+                codeowners_decoded = base64.b64decode(blob.content)
             else:
                 codeowners_decoded = codeowners_file_contents.decoded_content
 
@@ -193,7 +195,8 @@ def main():  # pragma: no cover
                     break
 
                 # Check to see if the username is a member of the organization
-                if not gh_org.has_in_members(username):
+                member = github_connection.get_user(username)
+                if not gh_org.has_in_members(member):
                     print(
                         f"\t{username} is not a member of {org}. Suggest removing them from {repo.full_name}"
                     )
@@ -238,8 +241,12 @@ def main():  # pragma: no cover
                     pull_count += 1
                     pull_request_urls.append(pull.html_url)
                     print(f"\tCreated pull request {pull.html_url}")
-                except GithubException:
-                    print("\tFailed to create pull request. Check write permissions.")
+                except GithubException as e:
+                    print(
+                        f"\tFailed to create pull request"
+                        f" (status {e.status}): {e.data}."
+                        f" Check write permissions."
+                    )
                     continue
     except Exception as e:  # pylint: disable=broad-exception-caught
         error_message = str(e)
@@ -292,7 +299,7 @@ def get_codeowners_file(repo):
             codeowners_file_contents = repo.get_contents(path)
             if codeowners_file_contents:
                 return codeowners_file_contents, path
-        except GithubException:
+        except UnknownObjectException:
             continue
     return None, None
 

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -195,8 +195,12 @@ def main():  # pragma: no cover
                     break
 
                 # Check to see if the username is a member of the organization
-                member = github_connection.get_user(username)
-                if not gh_org.has_in_members(member):
+                try:
+                    member = github_connection.get_user(username)
+                    is_member = gh_org.has_in_members(member)
+                except UnknownObjectException:
+                    is_member = False
+                if not is_member:
                     print(
                         f"\t{username} is not a member of {org}. Suggest removing them from {repo.full_name}"
                     )

--- a/cleanowners.py
+++ b/cleanowners.py
@@ -1,19 +1,20 @@
 """A GitHub Action to suggest removal of non-organization members from CODEOWNERS files."""
 
+import base64
 import re
 import uuid
 
 import auth
 import env
-import github3
+from github import GithubException
 from markdown_writer import write_step_summary, write_to_markdown
 
 
 def get_org(github_connection, organization):
     """Get the organization object"""
     try:
-        return github_connection.organization(organization)
-    except github3.exceptions.NotFoundError:
+        return github_connection.get_organization(organization)
+    except GithubException:
         print(f"Organization {organization} not found")
         return None
 
@@ -164,19 +165,19 @@ def main():  # pragma: no cover
                     pull_count += 1
                     pull_request_urls.append(pull.html_url)
                     print(f"\tCreated pull request {pull.html_url}")
-                except github3.exceptions.NotFoundError:
+                except GithubException:
                     print("\tFailed to create pull request. Check write permissions.")
                 continue
 
             codeowners_count += 1
 
             if codeowners_file_contents.content is None:
-                # This is a large file so we need to get the sha and download based off the sha
-                codeowners_decoded = repo.blob(
-                    repo.file_contents(codeowners_filepath).sha
-                ).decode_content()
+                blob = repo.get_git_blob(repo.get_contents(codeowners_filepath).sha)
+                codeowners_decoded = blob.content.encode("utf-8")
+                if blob.encoding == "base64":
+                    codeowners_decoded = base64.b64decode(blob.content)
             else:
-                codeowners_decoded = codeowners_file_contents.decoded
+                codeowners_decoded = codeowners_file_contents.decoded_content
 
             # Extract the usernames from the CODEOWNERS file
             usernames = get_usernames_from_codeowners(codeowners_decoded)
@@ -192,7 +193,7 @@ def main():  # pragma: no cover
                     break
 
                 # Check to see if the username is a member of the organization
-                if not gh_org.is_member(username):
+                if not gh_org.has_in_members(username):
                     print(
                         f"\t{username} is not a member of {org}. Suggest removing them from {repo.full_name}"
                     )
@@ -237,7 +238,7 @@ def main():  # pragma: no cover
                     pull_count += 1
                     pull_request_urls.append(pull.html_url)
                     print(f"\tCreated pull request {pull.html_url}")
-                except github3.exceptions.NotFoundError:
+                except GithubException:
                     print("\tFailed to create pull request. Check write permissions.")
                     continue
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -288,10 +289,10 @@ def get_codeowners_file(repo):
     codeowners_file_contents = None
     for path in (".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"):
         try:
-            codeowners_file_contents = repo.file_contents(path)
+            codeowners_file_contents = repo.get_contents(path)
             if codeowners_file_contents:
                 return codeowners_file_contents, path
-        except github3.exceptions.NotFoundError:
+        except GithubException:
             continue
     return None, None
 
@@ -322,13 +323,10 @@ def get_repos_iterator(organization, repository_list, github_connection):
     """Get the repositories from the organization or list of repositories"""
     repos = []
     if organization and not repository_list:
-        repos = github_connection.organization(organization).repositories()
+        repos = github_connection.get_organization(organization).get_repos()
     else:
-        # Get the repositories from the repository_list
         for full_repo_path in repository_list:
-            org = full_repo_path.split("/")[0]
-            repo = full_repo_path.split("/")[1]
-            repos.append(github_connection.repository(org, repo))
+            repos.append(github_connection.get_repo(full_repo_path))
 
     return repos
 
@@ -387,11 +385,10 @@ def commit_changes(
 ):
     """Commit the changes to the repo and open a pull request and return the pull request object"""
     default_branch = repo.default_branch
-    # Get latest commit sha from default branch
-    default_branch_commit = repo.ref(f"heads/{default_branch}").object.sha
+    default_branch_commit = repo.get_git_ref(f"heads/{default_branch}").object.sha
     front_matter = "refs/heads/"
     branch_name = f"codeowners-{str(uuid.uuid4())}"
-    repo.create_ref(front_matter + branch_name, default_branch_commit)
+    repo.create_git_ref(front_matter + branch_name, default_branch_commit)
     if create_new:
         repo.create_file(
             codeowners_filepath,
@@ -400,9 +397,12 @@ def commit_changes(
             branch=branch_name,
         )
     else:
-        repo.file_contents(codeowners_filepath).update(
-            message=commit_message,
-            content=codeowners_file_contents_new,
+        existing_file = repo.get_contents(codeowners_filepath, ref=branch_name)
+        repo.update_file(
+            codeowners_filepath,
+            commit_message,
+            codeowners_file_contents_new,
+            existing_file.sha,
             branch=branch_name,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,8 @@ version = "2.0.0"
 description = "GitHub Action that cleans up CODEOWNERS files by removing users who are no longer part of the organization."
 requires-python = ">=3.11"
 dependencies = [
-    "github3-py==4.0.1",
+    "PyGithub>=2.6.0",
     "python-dotenv==1.2.2",
-    "requests==2.34.2",
 ]
 
 [dependency-groups]
@@ -19,5 +18,4 @@ dev = [
     "pylint==4.0.6",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "types-requests==2.33.0.20260518",
 ]

--- a/test_auth.py
+++ b/test_auth.py
@@ -21,7 +21,7 @@ class TestAuth(unittest.TestCase):
         mock_auth.Token.return_value = mock_token
         mock_github.return_value = "Authenticated to GitHub.com"
 
-        result = auth.auth_to_github("token", "", "", b"", "", False)
+        result = auth.auth_to_github("token", None, None, b"", "", False)
 
         mock_auth.Token.assert_called_once_with("token")
         mock_github.assert_called_once_with(auth=mock_token)
@@ -33,7 +33,7 @@ class TestAuth(unittest.TestCase):
         Expect a ValueError to be raised.
         """
         with self.assertRaises(ValueError) as context_manager:
-            auth.auth_to_github("", "", "", b"", "", False)
+            auth.auth_to_github("", None, None, b"", "", False)
         the_exception = context_manager.exception
         self.assertEqual(
             str(the_exception),
@@ -50,7 +50,7 @@ class TestAuth(unittest.TestCase):
         mock_auth.Token.return_value = mock_token
         mock_github.return_value = "Authenticated to GitHub Enterprise"
         result = auth.auth_to_github(
-            "token", "", "", b"", "https://github.example.com", False
+            "token", None, None, b"", "https://github.example.com", False
         )
 
         mock_auth.Token.assert_called_once_with("token")
@@ -72,7 +72,7 @@ class TestAuth(unittest.TestCase):
         mock_github.return_value = MagicMock()
 
         result = auth.auth_to_github(
-            "", "123", "123", b"123", "https://github.example.com", True
+            "", 123, 123, b"123", "https://github.example.com", True
         )
 
         mock_auth.AppAuth.assert_called_once_with(123, "123")
@@ -96,7 +96,7 @@ class TestAuth(unittest.TestCase):
         mock_github.return_value = MagicMock()
 
         result = auth.auth_to_github(
-            "", "123", "123", b"123", "https://github.example.com", False
+            "", 123, 123, b"123", "https://github.example.com", False
         )
 
         mock_auth.AppAuth.assert_called_once_with(123, "123")

--- a/test_auth.py
+++ b/test_auth.py
@@ -11,15 +11,20 @@ class TestAuth(unittest.TestCase):
     Test case for the auth module.
     """
 
-    @patch("github3.login")
-    def test_auth_to_github_with_token(self, mock_login):
+    @patch("auth.Github")
+    @patch("auth.Auth")
+    def test_auth_to_github_with_token(self, mock_auth, mock_github):
         """
         Test the auth_to_github function when the token is provided.
         """
-        mock_login.return_value = "Authenticated to GitHub.com"
+        mock_token = MagicMock()
+        mock_auth.Token.return_value = mock_token
+        mock_github.return_value = "Authenticated to GitHub.com"
 
         result = auth.auth_to_github("token", "", "", b"", "", False)
 
+        mock_auth.Token.assert_called_once_with("token")
+        mock_github.assert_called_once_with(auth=mock_token)
         self.assertEqual(result, "Authenticated to GitHub.com")
 
     def test_auth_to_github_without_token(self):
@@ -35,73 +40,87 @@ class TestAuth(unittest.TestCase):
             "GH_TOKEN or the set of [GH_APP_ID, GH_APP_INSTALLATION_ID, GH_APP_PRIVATE_KEY] environment variables are not set",
         )
 
-    @patch("github3.github.GitHubEnterprise")
-    def test_auth_to_github_with_ghe(self, mock_ghe):
+    @patch("auth.Github")
+    @patch("auth.Auth")
+    def test_auth_to_github_with_ghe(self, mock_auth, mock_github):
         """
         Test the auth_to_github function when the GitHub Enterprise URL is provided.
         """
-        mock_ghe.return_value = "Authenticated to GitHub Enterprise"
+        mock_token = MagicMock()
+        mock_auth.Token.return_value = mock_token
+        mock_github.return_value = "Authenticated to GitHub Enterprise"
         result = auth.auth_to_github(
             "token", "", "", b"", "https://github.example.com", False
         )
 
+        mock_auth.Token.assert_called_once_with("token")
+        mock_github.assert_called_once_with(
+            base_url="https://github.example.com/api/v3", auth=mock_token
+        )
         self.assertEqual(result, "Authenticated to GitHub Enterprise")
 
-    @patch("github3.github.GitHubEnterprise")
-    def test_auth_to_github_with_ghe_and_ghe_app(self, mock_ghe):
+    @patch("auth.Github")
+    @patch("auth.Auth")
+    def test_auth_to_github_with_ghe_and_ghe_app(self, mock_auth, mock_github):
         """
         Test the auth_to_github function when the GitHub Enterprise URL is provided and the app was created in GitHub Enterprise URL.
         """
-        mock = mock_ghe.return_value
-        mock.login_as_app_installation = MagicMock(return_value=True)
+        mock_app_auth = MagicMock()
+        mock_installation_auth = MagicMock()
+        mock_auth.AppAuth.return_value = mock_app_auth
+        mock_app_auth.get_installation_auth.return_value = mock_installation_auth
+        mock_github.return_value = MagicMock()
+
         result = auth.auth_to_github(
             "", "123", "123", b"123", "https://github.example.com", True
         )
-        mock.login_as_app_installation.assert_called_once_with(b"123", "123", "123")
-        self.assertEqual(result, mock)
 
-    @patch("github3.github.GitHub")
-    def test_auth_to_github_with_app(self, mock_gh):
+        mock_auth.AppAuth.assert_called_once_with(123, "123")
+        mock_app_auth.get_installation_auth.assert_called_once_with(123)
+        mock_github.assert_called_once_with(
+            base_url="https://github.example.com/api/v3",
+            auth=mock_installation_auth,
+        )
+        self.assertEqual(result, mock_github.return_value)
+
+    @patch("auth.Github")
+    @patch("auth.Auth")
+    def test_auth_to_github_with_app(self, mock_auth, mock_github):
         """
         Test the auth_to_github function when app credentials are provided
         """
-        mock = mock_gh.return_value
-        mock.login_as_app_installation = MagicMock(return_value=True)
+        mock_app_auth = MagicMock()
+        mock_installation_auth = MagicMock()
+        mock_auth.AppAuth.return_value = mock_app_auth
+        mock_app_auth.get_installation_auth.return_value = mock_installation_auth
+        mock_github.return_value = MagicMock()
+
         result = auth.auth_to_github(
             "", "123", "123", b"123", "https://github.example.com", False
         )
-        mock.login_as_app_installation.assert_called_once_with(b"123", "123", "123")
-        self.assertEqual(result, mock)
 
-    @patch("github3.github.GitHub")
-    def test_auth_to_github_with_app_int_app_id(self, mock_gh):
+        mock_auth.AppAuth.assert_called_once_with(123, "123")
+        mock_app_auth.get_installation_auth.assert_called_once_with(123)
+        mock_github.assert_called_once_with(auth=mock_installation_auth)
+        self.assertEqual(result, mock_github.return_value)
+
+    @patch("auth.Github")
+    @patch("auth.Auth")
+    def test_auth_to_github_with_app_int_app_id(self, mock_auth, mock_github):
         """
-        Test that an integer app_id is converted to a string before passing
-        to login_as_app_installation, to avoid PyJWT TypeError on the iss claim.
+        Test that an integer app_id is converted properly for Auth.AppAuth.
         """
-        mock = mock_gh.return_value
-        mock.login_as_app_installation = MagicMock(return_value=True)
+        mock_app_auth = MagicMock()
+        mock_installation_auth = MagicMock()
+        mock_auth.AppAuth.return_value = mock_app_auth
+        mock_app_auth.get_installation_auth.return_value = mock_installation_auth
+        mock_github.return_value = MagicMock()
+
         result = auth.auth_to_github("", 123, 456, b"private_key", "", False)
-        mock.login_as_app_installation.assert_called_once_with(
-            b"private_key", "123", 456
-        )
-        self.assertEqual(result, mock)
 
-    @patch("github3.login")
-    def test_auth_to_github_invalid_credentials(self, mock_login):
-        """
-        Test the auth_to_github function raises correct ValueError
-        when credentials are present but incorrect.
-        """
-        mock_login.return_value = None
-        with self.assertRaises(ValueError) as context_manager:
-            auth.auth_to_github("not_a_valid_token", "", "", b"", "", False)
-
-        the_exception = context_manager.exception
-        self.assertEqual(
-            str(the_exception),
-            "Unable to authenticate to GitHub",
-        )
+        mock_auth.AppAuth.assert_called_once_with(123, "private_key")
+        mock_app_auth.get_installation_auth.assert_called_once_with(456)
+        self.assertEqual(result, mock_github.return_value)
 
 
 if __name__ == "__main__":

--- a/test_cleanowners.py
+++ b/test_cleanowners.py
@@ -5,7 +5,6 @@ import uuid
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
-import github3
 from cleanowners import (
     build_default_codeowners,
     cleanup_whitespace,
@@ -17,6 +16,7 @@ from cleanowners import (
     print_stats,
     remove_username_from_content,
 )
+from github import GithubException
 
 
 class TestCommitChanges(unittest.TestCase):
@@ -25,15 +25,15 @@ class TestCommitChanges(unittest.TestCase):
     @patch("uuid.uuid4")
     def test_commit_changes(self, mock_uuid):
         """Test the commit_changes function."""
-        mock_uuid.return_value = uuid.UUID(
-            "12345678123456781234567812345678"
-        )  # Mock UUID generation
-        mock_repo = MagicMock()  # Mock repo object
+        mock_uuid.return_value = uuid.UUID("12345678123456781234567812345678")
+        mock_repo = MagicMock()
         mock_repo.default_branch = "main"
-        mock_repo.ref.return_value.object.sha = "abc123"  # Mock SHA for latest commit
-        mock_repo.create_ref.return_value = True
-        mock_repo.file_contents.return_value = MagicMock()
-        mock_repo.file_contents.update.return_value = True
+        mock_repo.get_git_ref.return_value.object.sha = "abc123"
+        mock_repo.create_git_ref.return_value = True
+        mock_existing_file = MagicMock()
+        mock_existing_file.sha = "existing_sha"
+        mock_repo.get_contents.return_value = mock_existing_file
+        mock_repo.update_file.return_value = True
         mock_repo.create_pull.return_value = "MockPullRequest"
 
         title = "Test Title"
@@ -50,11 +50,17 @@ class TestCommitChanges(unittest.TestCase):
             "CODEOWNERS",
         )
 
-        # Assert that the methods were called with the correct arguments
-        mock_repo.create_ref.assert_called_once_with(
+        mock_repo.create_git_ref.assert_called_once_with(
             f"refs/heads/{branch_name}", "abc123"
         )
-        mock_repo.file_contents.assert_called_once_with("CODEOWNERS")
+        mock_repo.get_contents.assert_called_once_with("CODEOWNERS", ref=branch_name)
+        mock_repo.update_file.assert_called_once_with(
+            "CODEOWNERS",
+            commit_message,
+            dependabot_file,
+            "existing_sha",
+            branch=branch_name,
+        )
         mock_repo.create_pull.assert_called_once_with(
             title=title,
             body=body,
@@ -62,7 +68,6 @@ class TestCommitChanges(unittest.TestCase):
             base="main",
         )
 
-        # Assert that the function returned the expected result
         self.assertEqual(result, "MockPullRequest")
 
     @patch("uuid.uuid4")
@@ -71,8 +76,8 @@ class TestCommitChanges(unittest.TestCase):
         mock_uuid.return_value = uuid.UUID("12345678123456781234567812345678")
         mock_repo = MagicMock()
         mock_repo.default_branch = "main"
-        mock_repo.ref.return_value.object.sha = "abc123"
-        mock_repo.create_ref.return_value = True
+        mock_repo.get_git_ref.return_value.object.sha = "abc123"
+        mock_repo.create_git_ref.return_value = True
         mock_repo.create_file.return_value = True
         mock_repo.create_pull.return_value = "MockPullRequest"
 
@@ -87,7 +92,7 @@ class TestCommitChanges(unittest.TestCase):
         )
 
         branch_name = "codeowners-12345678-1234-5678-1234-567812345678"
-        mock_repo.create_ref.assert_called_once_with(
+        mock_repo.create_git_ref.assert_called_once_with(
             f"refs/heads/{branch_name}", "abc123"
         )
         mock_repo.create_file.assert_called_once_with(
@@ -96,7 +101,7 @@ class TestCommitChanges(unittest.TestCase):
             b"new content",
             branch=branch_name,
         )
-        mock_repo.file_contents.assert_not_called()
+        mock_repo.get_contents.assert_not_called()
         self.assertEqual(result, "MockPullRequest")
 
 
@@ -269,82 +274,71 @@ class TestGetUsernamesFromCodeowners(unittest.TestCase):
 class TestGetOrganization(unittest.TestCase):
     """Test the get_org function in cleanowners.py"""
 
-    @patch("github3.login")
-    def test_get_organization_succeeds(self, mock_github):
+    def test_get_organization_succeeds(self):
         """Test the organization is valid."""
         organization = "my_organization"
-        github_connection = mock_github.return_value
+        github_connection = MagicMock()
 
         mock_organization = MagicMock()
-        github_connection.organization.return_value = mock_organization
+        github_connection.get_organization.return_value = mock_organization
 
         result = get_org(github_connection, organization)
 
-        github_connection.organization.assert_called_once_with(organization)
+        github_connection.get_organization.assert_called_once_with(organization)
         self.assertEqual(result, mock_organization)
 
-    @patch("github3.login")
-    def test_get_organization_fails(self, mock_github):
+    def test_get_organization_fails(self):
         """Test the organization is not valid."""
         organization = "my_organization"
-        github_connection = mock_github.return_value
+        github_connection = MagicMock()
 
-        github_connection.organization.side_effect = github3.exceptions.NotFoundError(
-            resp=MagicMock(status_code=404)
+        github_connection.get_organization.side_effect = GithubException(
+            404, {"message": "Not Found"}, None
         )
         result = get_org(github_connection, organization)
 
-        github_connection.organization.assert_called_once_with(organization)
+        github_connection.get_organization.assert_called_once_with(organization)
         self.assertIsNone(result)
 
 
 class TestGetReposIterator(unittest.TestCase):
     """Test the get_repos_iterator function in evergreen.py"""
 
-    @patch("github3.login")
-    def test_get_repos_iterator_with_organization(self, mock_github):
+    def test_get_repos_iterator_with_organization(self):
         """Test the get_repos_iterator function with an organization"""
         organization = "my_organization"
         repository_list = []
-        github_connection = mock_github.return_value
+        github_connection = MagicMock()
 
         mock_organization = MagicMock()
         mock_repositories = MagicMock()
-        mock_organization.repositories.return_value = mock_repositories
-        github_connection.organization.return_value = mock_organization
+        mock_organization.get_repos.return_value = mock_repositories
+        github_connection.get_organization.return_value = mock_organization
 
         result = get_repos_iterator(organization, repository_list, github_connection)
 
-        # Assert that the organization method was called with the correct argument
-        github_connection.organization.assert_called_once_with(organization)
-
-        # Assert that the repositories method was called on the organization object
-        mock_organization.repositories.assert_called_once()
-
-        # Assert that the function returned the expected result
+        github_connection.get_organization.assert_called_once_with(organization)
+        mock_organization.get_repos.assert_called_once()
         self.assertEqual(result, mock_repositories)
 
-    @patch("github3.login")
-    def test_get_repos_iterator_with_repository_list(self, mock_github):
+    def test_get_repos_iterator_with_repository_list(self):
         """Test the get_repos_iterator function with a repository list"""
         organization = None
         repository_list = ["org/repo1", "org2/repo2"]
-        github_connection = mock_github.return_value
+        github_connection = MagicMock()
 
         mock_repository = MagicMock()
         mock_repository_list = [mock_repository, mock_repository]
-        github_connection.repository.side_effect = mock_repository_list
+        github_connection.get_repo.side_effect = mock_repository_list
 
         result = get_repos_iterator(organization, repository_list, github_connection)
 
-        # Assert that the repository method was called with the correct arguments for each repository in the list
         expected_calls = [
-            unittest.mock.call("org", "repo1"),
-            unittest.mock.call("org2", "repo2"),
+            unittest.mock.call("org/repo1"),
+            unittest.mock.call("org2/repo2"),
         ]
-        github_connection.repository.assert_has_calls(expected_calls)
+        github_connection.get_repo.assert_has_calls(expected_calls)
 
-        # Assert that the function returned the expected result
         self.assertEqual(result, mock_repository_list)
 
 
@@ -402,7 +396,7 @@ class TestGetCodeownersFile(unittest.TestCase):
 
     def test_codeowners_in_github_folder(self):
         """Test that a CODEOWNERS file in the .github folder is considered valid."""
-        self.repo.file_contents.side_effect = lambda path: (
+        self.repo.get_contents.side_effect = lambda path: (
             MagicMock(size=1) if path == ".github/CODEOWNERS" else None
         )
         contents, path = get_codeowners_file(self.repo)
@@ -411,7 +405,7 @@ class TestGetCodeownersFile(unittest.TestCase):
 
     def test_codeowners_in_root(self):
         """Test that a CODEOWNERS file in the root is considered valid."""
-        self.repo.file_contents.side_effect = lambda path: (
+        self.repo.get_contents.side_effect = lambda path: (
             MagicMock(size=1) if path == "CODEOWNERS" else None
         )
         contents, path = get_codeowners_file(self.repo)
@@ -420,7 +414,7 @@ class TestGetCodeownersFile(unittest.TestCase):
 
     def test_codeowners_in_docs_folder(self):
         """Test that a CODEOWNERS file in a docs folder is considered valid."""
-        self.repo.file_contents.side_effect = lambda path: (
+        self.repo.get_contents.side_effect = lambda path: (
             MagicMock(size=1) if path == "docs/CODEOWNERS" else None
         )
         contents, path = get_codeowners_file(self.repo)
@@ -429,22 +423,22 @@ class TestGetCodeownersFile(unittest.TestCase):
 
     def test_codeowners_not_found(self):
         """Test that a missing CODEOWNERS file is not considered valid because it doesn't exist."""
-        self.repo.file_contents.side_effect = lambda path: None
+        self.repo.get_contents.side_effect = lambda path: None
         contents, path = get_codeowners_file(self.repo)
         self.assertIsNone(contents)
         self.assertIsNone(path)
 
     def test_codeowners_empty_file(self):
         """Test that an empty CODEOWNERS file is returned for further handling."""
-        self.repo.file_contents.side_effect = lambda path: MagicMock(size=0)
+        self.repo.get_contents.side_effect = lambda path: MagicMock(size=0)
         contents, path = get_codeowners_file(self.repo)
         self.assertIsNotNone(contents)
         self.assertEqual(path, ".github/CODEOWNERS")
 
     def test_codeowners_not_found_then_found(self):
         """Test that a later path is used when earlier ones are not found."""
-        not_found = github3.exceptions.NotFoundError(resp=MagicMock(status_code=404))
-        self.repo.file_contents.side_effect = [not_found, MagicMock(size=1)]
+        not_found = GithubException(404, {"message": "Not Found"}, None)
+        self.repo.get_contents.side_effect = [not_found, MagicMock(size=1)]
         contents, path = get_codeowners_file(self.repo)
         self.assertIsNotNone(contents)
         self.assertEqual(path, "CODEOWNERS")

--- a/test_cleanowners.py
+++ b/test_cleanowners.py
@@ -16,7 +16,7 @@ from cleanowners import (
     print_stats,
     remove_username_from_content,
 )
-from github import GithubException
+from github import UnknownObjectException
 
 
 class TestCommitChanges(unittest.TestCase):
@@ -292,7 +292,7 @@ class TestGetOrganization(unittest.TestCase):
         organization = "my_organization"
         github_connection = MagicMock()
 
-        github_connection.get_organization.side_effect = GithubException(
+        github_connection.get_organization.side_effect = UnknownObjectException(
             404, {"message": "Not Found"}, None
         )
         result = get_org(github_connection, organization)
@@ -437,7 +437,7 @@ class TestGetCodeownersFile(unittest.TestCase):
 
     def test_codeowners_not_found_then_found(self):
         """Test that a later path is used when earlier ones are not found."""
-        not_found = GithubException(404, {"message": "Not Found"}, None)
+        not_found = UnknownObjectException(404, {"message": "Not Found"}, None)
         self.repo.get_contents.side_effect = [not_found, MagicMock(size=1)]
         contents, path = get_codeowners_file(self.repo)
         self.assertIsNotNone(contents)

--- a/uv.lock
+++ b/uv.lock
@@ -250,9 +250,8 @@ name = "cleanowners"
 version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "github3-py" },
+    { name = "pygithub" },
     { name = "python-dotenv" },
-    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -265,14 +264,12 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "github3-py", specifier = "==4.0.1" },
+    { name = "pygithub", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "requests", specifier = "==2.34.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -285,7 +282,6 @@ dev = [
     { name = "pylint", specifier = "==4.0.6" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
-    { name = "types-requests", specifier = "==2.33.0.20260518" },
 ]
 
 [[package]]
@@ -493,21 +489,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
-name = "github3-py"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "uritemplate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/89/91/603bcaf8cd1b3927de64bf56c3a8915f6653ea7281919140c5bcff2bfe7b/github3.py-4.0.1.tar.gz", hash = "sha256:30d571076753efc389edc7f9aaef338a4fcb24b54d8968d5f39b1342f45ddd36", size = 36214038, upload-time = "2023-04-26T17:56:37.677Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/2394d4fb542574678b0ba342daf734d4d811768da3c2ee0c84d509dcb26c/github3.py-4.0.1-py3-none-any.whl", hash = "sha256:a89af7de25650612d1da2f0609622bcdeb07ee8a45a1c06b2d16a05e4234e753", size = 151800, upload-time = "2023-04-26T17:56:25.015Z" },
 ]
 
 [[package]]
@@ -743,6 +724,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pygithub"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pynacl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -784,6 +781,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -811,18 +843,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -881,15 +901,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -956,33 +967,12 @@ wheels = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.33.0.20260518"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "uritemplate"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed Changes

Port from `github3.py` to `PyGithub` for GitHub API interactions, aligning this repo with the same library used across other community projects (pr-conflict-detector, measure-innersource).

## What/Why

`github3.py` is being replaced with `PyGithub` across OSPO projects for consistency. PyGithub handles retry/timeout internally, removing the need for the `requests` dependency.

## Proof it works

73 tests pass with 100% coverage.

## Risk + AI role

Low -- 1:1 API migration with no behavioral changes. AI-assisted (Claude Opus 4.6) with human review.

## Review focus

- Auth flow in `auth.py` -- App auth now uses `Auth.AppAuth` + `get_installation_auth` instead of `login_as_app_installation`
- Large file blob handling in `cleanowners.py` -- base64 decode path via `get_git_blob`

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing